### PR TITLE
Removed pypy and 3.2 as coverage doesn't support them

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Python PostgreSQL Sample [![Build Status](https://apibeta.shippable.com/projects
 Tests basic SQL commands using the psycopg2 driver for Python.
 
 This sample is built for Shippable, a docker based continuous integration and deployment platform.
+This sample project will fail when built with python 3.2 and pypy since the coverage package does not support python 3.2 and pypy. 
+https://github.com/menegazzo/travispy/issues/20 
+https://pypi.python.org/pypi/coverage/4.0.3

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,8 +1,15 @@
+build_image: drydock/u12pytpls:prod
 language: python
 
 python:
+  - 2.6
   - 2.7
-  
+  - 3.3
+  - 3.4
+  - 3.5
+  - pypy3
+services:
+  - postgres
 install:
   - pip install -r requirements.txt
 


### PR DESCRIPTION
fixes https://github.com/shippableSamples/sample_python_postgres/issues/2